### PR TITLE
Replace dict output with custom message class

### DIFF
--- a/nwbinspector/checks/nwb_containers.py
+++ b/nwbinspector/checks/nwb_containers.py
@@ -2,7 +2,7 @@
 import h5py
 from pynwb import NWBContainer
 
-from ..register_checks import register_check, Importance, Severity
+from ..register_checks import register_check, Importance, Severity, InspectorMessage
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=NWBContainer)
@@ -18,7 +18,9 @@ def check_dataset_compression(nwb_container: NWBContainer, gb_severity_threshold
                 severity = Severity.HIGH
             else:
                 severity = Severity.LOW
-            return dict(severity=severity, message="Consider enabling compression when writing a large dataset.")
+            return InspectorMessage(
+                severity=severity, message="Consider enabling compression when writing a large dataset."
+            )
 
 
 # TODO: break up extra logic

--- a/nwbinspector/checks/time_series.py
+++ b/nwbinspector/checks/time_series.py
@@ -4,7 +4,7 @@ import numpy as np
 import pynwb
 
 # from ..tools import all_of_type
-from ..register_checks import register_check, Importance, Severity
+from ..register_checks import register_check, Importance, Severity, InspectorMessage
 from ..utils import check_regular_series
 
 
@@ -19,7 +19,7 @@ def check_regular_timestamps(time_series: pynwb.TimeSeries, time_tol_decimals=9,
             severity = Severity.HIGH
         else:
             severity = Severity.LOW
-        return dict(
+        return InspectorMessage(
             severity=severity,
             message=(
                 "TimeSeries appears to have a constant sampling rate. "
@@ -33,7 +33,7 @@ def check_regular_timestamps(time_series: pynwb.TimeSeries, time_tol_decimals=9,
 def check_data_orientation(time_series: pynwb.TimeSeries):
     """If the TimeSeries has data, check if the longest axis (almost always time) is also the zero-axis."""
     if time_series.data is not None and any(np.array(time_series.data.shape[1:]) > time_series.data.shape[0]):
-        return dict(
+        return InspectorMessage(
             message=(
                 "Data may be in the wrong orientation. "
                 "Time should be in the first dimension, and is usually the longest dimension. "
@@ -50,7 +50,7 @@ def check_timestamps_match_first_dimension(time_series: pynwb.TimeSeries):
         and time_series.timestamps is not None
         and np.array(time_series.data).shape[:1] != np.array(time_series.timestamps).shape
     ):
-        return dict(
+        return InspectorMessage(
             message="The length of the first dimension of data does not match the length of timestamps.",
         )
 

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -10,7 +10,7 @@ import pynwb
 from natsort import natsorted
 
 from . import available_checks, Importance
-from .inspector_tools import organize_inspect_results, write_results, print_to_console
+from .inspector_tools import organize_check_results, write_results, print_to_console
 
 
 def main():
@@ -87,7 +87,7 @@ def main():
                     nwbfile=nwbfile, skip=args.skip, importance_threshold=Importance[args.importance_threshold]
                 )
                 if any(check_results):
-                    organized_results.update({str(nwbfile_path): organize_inspect_results(check_results=check_results)})
+                    organized_results.update({str(nwbfile_path): organize_check_results(check_results=check_results)})
         except Exception as ex:
             num_exceptions += 1
             print("ERROR: ", ex)

--- a/nwbinspector/register_checks.py
+++ b/nwbinspector/register_checks.py
@@ -2,6 +2,7 @@
 from collections import defaultdict, OrderedDict
 from functools import wraps
 from enum import Enum
+from dataclasses import dataclass
 
 import h5py
 
@@ -30,6 +31,19 @@ global available_checks
 available_checks = OrderedDict({importance: defaultdict(list) for importance in Importance})
 
 
+@dataclass
+class InspectorMessage:
+    """The primary result returned by every check."""
+
+    message: str
+    severity: Severity = None
+    importance: Importance = Importance.BEST_PRACTICE_SUGGESTION
+    check_function_name: str = ""
+    object_type: str = ""
+    object_name: str = ""
+    location: str = ""
+
+
 def register_check(importance, neurodata_type):
     """Wrap a check function to add it to the list of default checks for that severity and neurodata type."""
 
@@ -52,24 +66,20 @@ def register_check(importance, neurodata_type):
 
             auto_parsed_result = check_function(*args, **kwargs)
             if auto_parsed_result is not None:
-                if "severity" in auto_parsed_result:
-                    if auto_parsed_result["severity"] is None:  # For perfect consistency with not specifying
-                        auto_parsed_result["severity"] = Severity.NO_SEVERITY
-                    if auto_parsed_result["severity"] not in Severity:
-                        raise ValueError(
-                            f"Indicated severity ({auto_parsed_result['severity']}) of custom check "
-                            f"({check_function.__name__}) is not a valid severity level! Please choose one of "
-                            "Severity.HIGH, Severity.LOW, or do not specify any severity."
-                        )
+                if auto_parsed_result.severity is None:  # For perfect consistency with not specifying
+                    auto_parsed_result.severity = Severity.NO_SEVERITY
+                if auto_parsed_result.severity not in Severity:
+                    raise ValueError(
+                        f"Indicated severity ({auto_parsed_result.severity}) of custom check "
+                        f"({check_function.__name__}) is not a valid severity level! Please choose one of "
+                        "Severity.HIGH, Severity.LOW, or do not specify any severity."
+                    )
 
-                auto_parsed_result.update(
-                    importance=check_function.importance.name,
-                    severity=auto_parsed_result.get("severity", Severity.NO_SEVERITY).name,
-                    check_function_name=check_function.__name__,
-                    object_type=type(obj).__name__,
-                    object_name=obj.name,
-                    location=parse_location(nwbfile_object=obj),
-                )
+                auto_parsed_result.importance = check_function.importance
+                auto_parsed_result.check_function_name = check_function.__name__
+                auto_parsed_result.object_type = type(obj).__name__
+                auto_parsed_result.object_name = obj.name
+                auto_parsed_result.location = parse_location(nwbfile_object=obj)
             return auto_parsed_result
 
         available_checks[check_function.importance][check_function.neurodata_type].append(auto_parse_some_output)

--- a/nwbinspector/register_checks.py
+++ b/nwbinspector/register_checks.py
@@ -33,7 +33,22 @@ available_checks = OrderedDict({importance: defaultdict(list) for importance in 
 
 @dataclass
 class InspectorMessage:
-    """The primary result returned by every check."""
+    """
+    The primary output to be returned by every check function.
+
+    Parameters
+    ----------
+    message : str
+        A message that informs the user of the violation.
+    severity : Severity, optional
+        If a check of non-CRITICAL importance has some basis of comparison, such as magitude of affected data, then
+        the developer of the check may set the severity as Severity.HIGH or Severity.LOW by calling
+        `from nwbinspector.register_checks import Severity`. A good example is comparing if h5py.Dataset compression
+        has been enabled on smaller vs. larger objects (see nwbinspect/checks/nwb_containers.py for details).
+
+        The user will never directly see this severity, but it will prioritize the order in which check results are
+        presented by the NWBInspector.
+    """
 
     message: str
     severity: Severity = None

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -13,6 +13,7 @@ from pynwb import NWBFile, NWBHDF5IO, TimeSeries
 from pynwb.behavior import SpatialSeries, Position
 
 from nwbinspector.nwbinspector import inspect_nwb, Importance
+from nwbinspector.register_checks import Severity, InspectorMessage
 from nwbinspector.utils import FilePathType
 
 
@@ -115,70 +116,70 @@ class TestInspector(TestCase):
             written_nwbfile = io.read()
             test_results = inspect_nwb(nwbfile=written_nwbfile)
         true_results = [
-            dict(
-                severity="LOW",
+            InspectorMessage(
+                severity=Severity.LOW,
                 message="Consider enabling compression when writing a large dataset.",
-                importance="BEST_PRACTICE_VIOLATION",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
                 check_function_name="check_dataset_compression",
                 object_type="TimeSeries",
                 object_name="test_time_series_3",
                 location="/acquisition/",
             ),
-            dict(
-                severity="LOW",
+            InspectorMessage(
+                severity=Severity.LOW,
                 message="Consider enabling compression when writing a large dataset.",
-                importance="BEST_PRACTICE_VIOLATION",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
                 check_function_name="check_dataset_compression",
                 object_type="SpatialSeries",
                 object_name="my_spatial_series",
                 location="/processing/behavior/Position/",
             ),
-            dict(
-                severity="LOW",
+            InspectorMessage(
+                severity=Severity.LOW,
                 message="Consider enabling compression when writing a large dataset.",
-                importance="BEST_PRACTICE_VIOLATION",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
                 check_function_name="check_dataset_compression",
                 object_type="TimeSeries",
                 object_name="test_time_series_2",
                 location="/acquisition/",
             ),
-            dict(
-                severity="HIGH",
+            InspectorMessage(
+                severity=Severity.HIGH,
                 message="Consider enabling compression when writing a large dataset.",
-                importance="BEST_PRACTICE_VIOLATION",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
                 check_function_name="check_dataset_compression",
                 object_type="TimeSeries",
                 object_name="test_time_series_1",
                 location="/acquisition/",
             ),
-            dict(
-                severity="LOW",
+            InspectorMessage(
+                severity=Severity.LOW,
                 message=(
                     "TimeSeries appears to have a constant sampling rate. Consider specifying "
                     "starting_time=1.2 and rate=2.0 instead of timestamps."
                 ),
-                importance="BEST_PRACTICE_VIOLATION",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
                 check_function_name="check_regular_timestamps",
                 object_type="TimeSeries",
                 object_name="test_time_series_2",
                 location="/acquisition/",
             ),
-            dict(
-                severity="NO_SEVERITY",
+            InspectorMessage(
+                severity=Severity.NO_SEVERITY,
                 message=(
                     "Data may be in the wrong orientation. Time should be in the first dimension, and is "
                     "usually the longest dimension. Here, another dimension is longer. "
                 ),
-                importance="CRITICAL",
+                importance=Importance.CRITICAL,
                 check_function_name="check_data_orientation",
                 object_type="SpatialSeries",
                 object_name="my_spatial_series",
                 location="/processing/behavior/Position/",
             ),
-            dict(
-                severity="NO_SEVERITY",
+            InspectorMessage(
+                severity=Severity.NO_SEVERITY,
                 message="The length of the first dimension of data does not match the length of timestamps.",
-                importance="CRITICAL",
+                importance=Importance.CRITICAL,
                 check_function_name="check_timestamps_match_first_dimension",
                 object_type="TimeSeries",
                 object_name="test_time_series_3",
@@ -192,22 +193,22 @@ class TestInspector(TestCase):
             written_nwbfile = io.read()
             test_results = inspect_nwb(nwbfile=written_nwbfile, importance_threshold=Importance.CRITICAL)
         true_results = [
-            dict(
-                severity="NO_SEVERITY",
+            InspectorMessage(
+                severity=Severity.NO_SEVERITY,
                 message=(
                     "Data may be in the wrong orientation. Time should be in the first dimension, and is "
                     "usually the longest dimension. Here, another dimension is longer. "
                 ),
-                importance="CRITICAL",
+                importance=Importance.CRITICAL,
                 check_function_name="check_data_orientation",
                 object_type="SpatialSeries",
                 object_name="my_spatial_series",
                 location="/processing/behavior/Position/",
             ),
-            dict(
-                severity="NO_SEVERITY",
+            InspectorMessage(
+                severity=Severity.NO_SEVERITY,
                 message="The length of the first dimension of data does not match the length of timestamps.",
-                importance="CRITICAL",
+                importance=Importance.CRITICAL,
                 check_function_name="check_timestamps_match_first_dimension",
                 object_type="TimeSeries",
                 object_name="test_time_series_3",
@@ -217,29 +218,28 @@ class TestInspector(TestCase):
         self.assertListofDictEqual(test_list=test_results, true_list=true_results)
 
     def test_inspect_nwb_skip(self):
-        print(self.nwbfile_paths[0])
         with NWBHDF5IO(path=self.nwbfile_paths[0], mode="r") as io:
             written_nwbfile = io.read()
             test_results = inspect_nwb(
                 nwbfile=written_nwbfile, skip=["check_data_orientation", "check_dataset_compression"]
             )
         true_results = [
-            dict(
-                severity="LOW",
+            InspectorMessage(
+                severity=Severity.LOW,
                 message=(
                     "TimeSeries appears to have a constant sampling rate. Consider specifying "
                     "starting_time=1.2 and rate=2.0 instead of timestamps."
                 ),
-                importance="BEST_PRACTICE_VIOLATION",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
                 check_function_name="check_regular_timestamps",
                 object_type="TimeSeries",
                 object_name="test_time_series_2",
                 location="/acquisition/",
             ),
-            dict(
-                severity="NO_SEVERITY",
+            InspectorMessage(
+                severity=Severity.NO_SEVERITY,
                 message="The length of the first dimension of data does not match the length of timestamps.",
-                importance="CRITICAL",
+                importance=Importance.CRITICAL,
                 check_function_name="check_timestamps_match_first_dimension",
                 object_type="TimeSeries",
                 object_name="test_time_series_3",

--- a/tests/test_register_check.py
+++ b/tests/test_register_check.py
@@ -7,7 +7,7 @@ from hdmf.common import DynamicTable
 from pynwb import TimeSeries
 from hdmf.testing import TestCase
 
-from nwbinspector.register_checks import register_check, Importance, Severity
+from nwbinspector.register_checks import register_check, Importance, Severity, InspectorMessage
 
 
 class TestRegisterClass(TestCase):
@@ -76,7 +76,7 @@ class TestRegisterClass(TestCase):
 
                 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=None)
                 def bad_severity_function(time_series: TimeSeries):
-                    return dict(severity=bad_severity)
+                    return InspectorMessage(severity=bad_severity, message="")
 
                 bad_severity_function(time_series=self.default_time_series)
 
@@ -92,7 +92,7 @@ class TestRegisterClass(TestCase):
 
                 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=None)
                 def bad_severity_function(time_series: TimeSeries):
-                    return dict(severity=bad_severity)
+                    return InspectorMessage(severity=bad_severity, message="")
 
                 bad_severity_function(time_series=self.default_time_series)
 
@@ -113,7 +113,7 @@ class TestRegisterClass(TestCase):
 
             @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=None)
             def bad_severity_function(time_series: TimeSeries):
-                return dict(severity=bad_severity)
+                return InspectorMessage(severity=bad_severity, message="")
 
             bad_severity_function(time_series=self.default_time_series)
 
@@ -123,13 +123,14 @@ class TestRegisterClass(TestCase):
 
             @register_check(importance=importance, neurodata_type=TimeSeries)
             def good_check_function(time_series: TimeSeries):
-                return dict(severity=severity)
+                return InspectorMessage(severity=severity, message="")
 
             self.assertEqual(
                 first=good_check_function(time_series=self.default_time_series),
-                second=dict(
-                    severity=severity.name,
-                    importance=importance.name,
+                second=InspectorMessage(
+                    severity=severity,
+                    message="",
+                    importance=importance,
                     check_function_name="good_check_function",
                     object_type="TimeSeries",
                     object_name="temp",
@@ -142,13 +143,14 @@ class TestRegisterClass(TestCase):
 
         @register_check(importance=importance, neurodata_type=TimeSeries)
         def good_check_function(time_series: TimeSeries):
-            return dict(severity=None)
+            return InspectorMessage(severity=None, message="")
 
         self.assertEqual(
             first=good_check_function(time_series=self.default_time_series),
-            second=dict(
-                severity=Severity.NO_SEVERITY.name,
-                importance=importance.name,
+            second=InspectorMessage(
+                severity=Severity.NO_SEVERITY,
+                message="",
+                importance=importance,
                 check_function_name="good_check_function",
                 object_type="TimeSeries",
                 object_name="temp",
@@ -161,13 +163,14 @@ class TestRegisterClass(TestCase):
 
         @register_check(importance=importance, neurodata_type=TimeSeries)
         def good_check_function(time_series: TimeSeries):
-            return dict()
+            return InspectorMessage(message="")
 
         self.assertEqual(
             first=good_check_function(time_series=self.default_time_series),
-            second=dict(
-                severity=Severity.NO_SEVERITY.name,
-                importance=importance.name,
+            second=InspectorMessage(
+                severity=Severity.NO_SEVERITY,
+                message="",
+                importance=importance,
                 check_function_name="good_check_function",
                 object_type="TimeSeries",
                 object_name="temp",

--- a/tests/unit_tests/test_containers.py
+++ b/tests/unit_tests/test_containers.py
@@ -8,7 +8,8 @@ from unittest import TestCase
 import h5py
 from pynwb import NWBContainer
 
-from nwbinspector import check_dataset_compression
+from nwbinspector import check_dataset_compression, Importance
+from nwbinspector.register_checks import Severity, InspectorMessage
 
 
 class TestNWBContainers(TestCase):
@@ -31,59 +32,61 @@ class TestNWBContainers(TestCase):
     def test_check_dataset_compression_below_default_threshold(self):
         with h5py.File(name=self.file_path, mode="w") as file:
             nwb_container = self.add_dataset_to_nwb_container(file=file, gb_size=0.1)
-            true_output = dict(
-                severity="LOW",
+            true_output = InspectorMessage(
+                severity=Severity.LOW,
                 message="Consider enabling compression when writing a large dataset.",
-                importance="BEST_PRACTICE_VIOLATION",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
                 check_function_name="check_dataset_compression",
                 object_type="NWBContainer",
                 object_name="test_container",
                 location="/",
             )
-            self.assertDictEqual(d1=check_dataset_compression(nwb_container=nwb_container), d2=true_output)
+            self.assertEqual(first=check_dataset_compression(nwb_container=nwb_container), second=true_output)
 
     def test_check_dataset_compression_above_default_threshold(self):
         with h5py.File(name=self.file_path, mode="w") as file:
             nwb_container = self.add_dataset_to_nwb_container(file=file, gb_size=1.1)
-            true_output = dict(
-                severity="HIGH",
+            true_output = InspectorMessage(
+                severity=Severity.HIGH,
                 message="Consider enabling compression when writing a large dataset.",
-                importance="BEST_PRACTICE_VIOLATION",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
                 check_function_name="check_dataset_compression",
                 object_type="NWBContainer",
                 object_name="test_container",
                 location="/",
             )
-            self.assertDictEqual(d1=check_dataset_compression(nwb_container=nwb_container), d2=true_output)
+            self.assertEqual(first=check_dataset_compression(nwb_container=nwb_container), second=true_output)
 
     def test_check_dataset_compression_below_manual_threshold(self):
         with h5py.File(name=self.file_path, mode="w") as file:
             nwb_container = self.add_dataset_to_nwb_container(file=file, gb_size=0.1)
-            true_output = dict(
-                severity="LOW",
+            true_output = InspectorMessage(
+                severity=Severity.LOW,
                 message="Consider enabling compression when writing a large dataset.",
-                importance="BEST_PRACTICE_VIOLATION",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
                 check_function_name="check_dataset_compression",
                 object_type="NWBContainer",
                 object_name="test_container",
                 location="/",
             )
-            self.assertDictEqual(
-                d1=check_dataset_compression(nwb_container=nwb_container, gb_severity_threshold=0.15), d2=true_output
+            self.assertEqual(
+                first=check_dataset_compression(nwb_container=nwb_container, gb_severity_threshold=0.15),
+                second=true_output,
             )
 
     def test_check_dataset_compression_above_manual_threshold(self):
         with h5py.File(name=self.file_path, mode="w") as file:
             nwb_container = self.add_dataset_to_nwb_container(file=file, gb_size=0.2)
-            true_output = dict(
-                severity="HIGH",
+            true_output = InspectorMessage(
+                severity=Severity.HIGH,
                 message="Consider enabling compression when writing a large dataset.",
-                importance="BEST_PRACTICE_VIOLATION",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
                 check_function_name="check_dataset_compression",
                 object_type="NWBContainer",
                 object_name="test_container",
                 location="/",
             )
-            self.assertDictEqual(
-                d1=check_dataset_compression(nwb_container=nwb_container, gb_severity_threshold=0.15), d2=true_output
+            self.assertEqual(
+                first=check_dataset_compression(nwb_container=nwb_container, gb_severity_threshold=0.15),
+                second=true_output,
             )

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -7,7 +7,9 @@ from nwbinspector import (
     check_regular_timestamps,
     check_data_orientation,
     check_timestamps_match_first_dimension,
+    Importance,
 )
+from nwbinspector import Severity, InspectorMessage
 
 
 def test_check_regular_timestamps():
@@ -18,13 +20,13 @@ def test_check_regular_timestamps():
             data=np.zeros(shape=3),
             timestamps=[1.2, 3.2, 5.2],
         )
-    ) == dict(
-        severity="LOW",
+    ) == InspectorMessage(
+        severity=Severity.LOW,
         message=(
             "TimeSeries appears to have a constant sampling rate. Consider specifying starting_time=1.2 and rate=2.0 "
             "instead of timestamps."
         ),
-        importance="BEST_PRACTICE_VIOLATION",
+        importance=Importance.BEST_PRACTICE_VIOLATION,
         check_function_name="check_regular_timestamps",
         object_type="TimeSeries",
         object_name="test_time_series",
@@ -40,14 +42,14 @@ def test_check_data_orientation():
             data=np.zeros(shape=(2, 100)),
             rate=1.0,
         )
-    ) == dict(
-        severity="NO_SEVERITY",
+    ) == InspectorMessage(
+        severity=Severity.NO_SEVERITY,
         message=(
             "Data may be in the wrong orientation. "
             "Time should be in the first dimension, and is usually the longest dimension. "
             "Here, another dimension is longer. "
         ),
-        importance="CRITICAL",
+        importance=Importance.CRITICAL,
         check_function_name="check_data_orientation",
         object_type="TimeSeries",
         object_name="test_time_series",
@@ -63,10 +65,10 @@ def test_check_timestamps():
             data=np.zeros(shape=4),
             timestamps=[1.0, 2.0, 3.0],
         )
-    ) == dict(
-        severity="NO_SEVERITY",
+    ) == InspectorMessage(
+        severity=Severity.NO_SEVERITY,
         message="The length of the first dimension of data does not match the length of timestamps.",
-        importance="CRITICAL",
+        importance=Importance.CRITICAL,
         check_function_name="check_timestamps_match_first_dimension",
         object_type="TimeSeries",
         object_name="test_time_series",
@@ -77,10 +79,10 @@ def test_check_timestamps():
 def test_check_timestamps_empty_data():
     assert check_timestamps_match_first_dimension(
         time_series=pynwb.TimeSeries(name="test_time_series", unit="test_units", data=[], timestamps=[1.0, 2.0, 3.0])
-    ) == dict(
-        severity="NO_SEVERITY",
+    ) == InspectorMessage(
+        severity=Severity.NO_SEVERITY,
         message="The length of the first dimension of data does not match the length of timestamps.",
-        importance="CRITICAL",
+        importance=Importance.CRITICAL,
         check_function_name="check_timestamps_match_first_dimension",
         object_type="TimeSeries",
         object_name="test_time_series",
@@ -91,10 +93,10 @@ def test_check_timestamps_empty_data():
 def test_check_timestamps_empty_timestamps():
     assert check_timestamps_match_first_dimension(
         time_series=pynwb.TimeSeries(name="test_time_series", unit="test_units", data=np.zeros(shape=4), timestamps=[])
-    ) == dict(
-        severity="NO_SEVERITY",
+    ) == InspectorMessage(
+        severity=Severity.NO_SEVERITY,
         message="The length of the first dimension of data does not match the length of timestamps.",
-        importance="CRITICAL",
+        importance=Importance.CRITICAL,
         check_function_name="check_timestamps_match_first_dimension",
         object_type="TimeSeries",
         object_name="test_time_series",


### PR DESCRIPTION
Suggestion by @oruebel; I wanted to open on different branch to access a changelog view for better comparison.

After working with it a bit here, I do think it is nicer as it does prevent the user from specifying invalid or unused keys in their output, which they could easily do on a basic dictionary. It also allows for more rigorous output parsing, and better capability of documentation for expected output for check functions.